### PR TITLE
Refs #10621: Don't deploy katello.yml during RPM build

### DIFF
--- a/rubygem-katello/rubygem-katello.spec
+++ b/rubygem-katello/rubygem-katello.spec
@@ -208,7 +208,6 @@ end
 GEMFILE
 
 unlink tmp
-cp %{buildroot}%{gem_instdir}/config/katello_defaults.yml %{buildroot}%{gem_instdir}/config/katello.yml
 
 export BUNDLER_EXT_NOSTRICT=1
 export BUNDLER_EXT_GROUPS="default assets katello"


### PR DESCRIPTION
The move to the use of SETTINGS included a set of default settings
within the engine declaration of the Katello engine. Thus, we no
longer need to deploy a katello.yaml file as we don't need custom
settings during build.
