### PR TITLE
Faster katello backup

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -55,19 +55,19 @@ else
   ]
 
   puts "Backing up config files... "
-  `tar --selinux -czvf config_files.tar.gz #{CONFIGS.join(' ')}`
+  `tar --selinux -czf config_files.tar.gz #{CONFIGS.join(' ')}`
   puts "Done."
 
   puts "Backing up Pulp data... "
-  `tar --selinux -czvf pulp_data.tar.gz /var/lib/pulp/ /var/www/pub/`
+  `tar --selinux -cf pulp_data.tar /var/lib/pulp/ /var/www/pub/`
   puts "Done."
 
   puts "Backing up postgres db... "
-  `tar --selinux -czvf pgsql_data.tar.gz /var/lib/pgsql/data/`
+  `tar --selinux -czf pgsql_data.tar.gz /var/lib/pgsql/data/`
   puts "Done."
 
   puts "Backing up mongo db... "
-  `tar --selinux -czvf mongo_data.tar.gz --exclude=mongod.lock /var/lib/mongodb/`
+  `tar --selinux -czf mongo_data.tar.gz --exclude=mongod.lock /var/lib/mongodb/`
   puts "Done."
 
   `service postgresql start`

--- a/katello/katello-restore
+++ b/katello/katello-restore
@@ -26,7 +26,7 @@ def restore
   puts "Done.\n"
 
   puts "Resetting Katello"
-  `tar --selinux --overwrite -xzvf config_files.tar.gz -C /`
+  `tar --selinux --overwrite -xzf config_files.tar.gz -C /`
   `katello-installer --reset`
   puts "Done.\n"
 
@@ -36,9 +36,9 @@ def restore
   puts "Done.\n"
 
   puts "Restoring backend data"
-  `tar --selinux --overwrite -xzvf pulp_data.tar.gz -C /`
-  `tar --selinux --overwrite -xzvf mongo_data.tar.gz -C /`
-  `tar --selinux --overwrite -xzvf pgsql_data.tar.gz -C /`
+  `tar --selinux --overwrite -xf pulp_data.tar -C /`
+  `tar --selinux --overwrite -xzf mongo_data.tar.gz -C /`
+  `tar --selinux --overwrite -xzf pgsql_data.tar.gz -C /`
   puts "Done.\n"
 
   puts "Restarting all Katello processes"


### PR DESCRIPTION
- don't compress pulp data -- RPMs are already compressed
- do not be verbose when calling tar
