### PR TITLE
Refs #12625 - include python-cherrypy as it was removed from epel7

### DIFF
--- a/comps/comps-katello-pulp-server-rhel7.xml
+++ b/comps/comps-katello-pulp-server-rhel7.xml
@@ -43,6 +43,7 @@
        <packagereq type="default">python-amqp</packagereq>       
        <packagereq type="default">python-billiard</packagereq>
        <packagereq type="default">python-celery</packagereq>
+       <packagereq type="default">python-cherrypy</packagereq>
        <packagereq type="default">python-crane</packagereq>
        <packagereq type="default">python-gofer</packagereq>
        <packagereq type="default">python-isodate</packagereq>


### PR DESCRIPTION
2.4 backport
