### PR TITLE
Fixes #12782 Updating katello-backup

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -51,7 +51,8 @@ else
     '/var/lib/foreman',
     '/var/lib/katello',
     '/var/lib/candlepin',
-    '/var/www/html/pub'
+    '/var/www/html/pub',
+    '/var/lib/puppet/foreman_cache_data'
   ]
 
   puts "Backing up config files... "


### PR DESCRIPTION
Updating katello-backup to capture /var/puppet/foreman_cache_data/
