### PR TITLE
Fixes #14125 - Removing gutterball from script

### DIFF
--- a/katello/katello-remove
+++ b/katello/katello-remove
@@ -56,6 +56,7 @@ CONFIG_FILES=(
     /etc/foreman-proxy/
     /etc/puppet/environments
     /etc/pki/katello-certs-tools
+    /etc/gutterball
 )
 
 LOG_FILES=(


### PR DESCRIPTION
removing /etc/gutterball from script to prevent keystore issues upon reinstall.
