### PR TITLE
Fixes #14189: Move repo definitions to be dist based 

### DIFF
--- a/repos/katello-client.repo
+++ b/repos/katello-client.repo
@@ -2,7 +2,7 @@
 
 [katello-client]
 name=Katello Client Nightly
-baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/client/@SUBDIR@/$releasever/$basearch/
+baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/client/@DIST@/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=1
 gpgcheck=0
@@ -12,7 +12,7 @@ priority=1
 
 [katello-client-source]
 name=Katello Client Nightly Source
-baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/client/@SUBDIR@/$releasever/
+baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/client/@DIST@/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=0
 gpgcheck=0

--- a/repos/katello-repos.spec
+++ b/repos/katello-repos.spec
@@ -40,17 +40,13 @@ rm -rf %{buildroot}
 #prepare dir structure
 install -d -m 0755 %{buildroot}%{_sysconfdir}/yum.repos.d
 install -d -m 0755 %{buildroot}%{_sysconfdir}/pki/rpm-gpg/
-# some sane default value
-%define reposubdir      RHEL
-# redefine on fedora
-%{?fedora: %define reposubdir      Fedora}
  
 install -m 644 %{SOURCE0} %{buildroot}%{_sysconfdir}/yum.repos.d/
 install -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/yum.repos.d/
 install -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-katello
 
 for repofile in %{buildroot}%{_sysconfdir}/yum.repos.d/*.repo; do
-    sed -i 's/@SUBDIR@/%{reposubdir}/' $repofile
+    sed -i 's/@DIST@/%{dist}/' $repofile
 done
 
 %clean

--- a/repos/katello.repo
+++ b/repos/katello.repo
@@ -2,7 +2,7 @@
 
 [katello]
 name=Katello Nightly
-baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/katello/@SUBDIR@/$releasever/$basearch/
+baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/katello/@DIST@/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=1
 gpgcheck=0
@@ -12,7 +12,7 @@ priority=1
 # copy of Pulp's packages in order to ensure compatibility
 [katello-pulp]
 name=Pulp Community Releases
-baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/pulp/@SUBDIR@/$releasever/$basearch/
+baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/pulp/@DIST@/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=1
 gpgcheck=0
@@ -23,7 +23,7 @@ priority=1
 
 [katello-candlepin]
 name=Candlepin: an open source entitlement management system.
-baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/candlepin/@SUBDIR@/$releasever/$basearch/
+baseurl=https://fedorapeople.org/groups/katello/releases/yum/nightly/candlepin/@DIST@/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=1
 gpgcheck=0
@@ -33,21 +33,21 @@ priority=1
 
 [katello-source]
 name=Katello Nightly Source
-baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/katello/@SUBDIR@/$releasever/
+baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/katello/@DIST@/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=0
 gpgcheck=0
 
 [katello-pulp-source]
 name=Katello Pulp source
-baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/pulp/@SUBDIR@/$releasever/
+baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/pulp/@DIST@/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=0
 gpgcheck=0
 
 [katello-candlepin-source]
 name=Katello Candlepin source
-baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/candlepin/@SUBDIR@/$releasever/
+baseurl=https://fedorapeople.org/groups/katello/releases/source/srpm/nightly/candlepin/@DIST@/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-katello
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
We were using subdirectories such as RHEL/7 and RHEL/7Server to
denote locations for different distributions. This moves to a dist
based approach (e.g. el7) to support more platforms such as 7Server,
Centos or something like 7Workstation.
