### PR TITLE
fixes #14784 - fix katello-backup syntax error

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -20,7 +20,7 @@ optparse = OptionParser.new do |opts|
     else
       opts.abort("Previous backup directory does not exist: #{dir_path}")
     end
-
+  end
   opts.on("--online-backup", "Backup Pulp data online") do |online|
     @options[:online] = online
   end

--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -21,6 +21,7 @@ optparse = OptionParser.new do |opts|
       opts.abort("Previous backup directory does not exist: #{dir_path}")
     end
   end
+  
   opts.on("--online-backup", "Backup Pulp data online") do |online|
     @options[:online] = online
   end


### PR DESCRIPTION
Fixed an error while trying to create Katello backup in 3.0 version

/usr/bin/katello-backup:115: syntax error, unexpected end-of-input, expecting keyword_end
