### PR TITLE
	Fix error with Katello-restore script `pulp_data'

### DIFF
--- a/katello/katello-restore
+++ b/katello/katello-restore
@@ -61,7 +61,7 @@ def confirm
 end
 
 if !DIR.nil? && File.directory?(DIR)
-  if Dir.entries(DIR).include?(pulp_data.tar)
+  if Dir.entries(DIR).include?("pulp_data.tar")
     confirmed ? restore : confirm
   else
     puts "**** Given directory does not include pulp content ****"

--- a/katello/katello-restore
+++ b/katello/katello-restore
@@ -61,7 +61,7 @@ def confirm
 end
 
 if !DIR.nil? && File.directory?(DIR)
-  if Dir.entries(DIR).include?("pulp_data.tar")
+  if Dir.entries(DIR).include?('pulp_data.tar')
     confirmed ? restore : confirm
   else
     puts "**** Given directory does not include pulp content ****"


### PR DESCRIPTION
Fix error with Katello-restore script: /usr/bin/katello-restore:64:in `<main>': undefined local variable or method`pulp_data' for main:Object (NameError)
