### PR TITLE
fixes #15012 - run katello-package-upload in %posttrans

### DIFF
--- a/katello-agent/katello-agent.spec
+++ b/katello-agent/katello-agent.spec
@@ -58,6 +58,10 @@ chkconfig goferd on
 service goferd restart > /dev/null 2>&1
 exit 0
 
+%posttrans
+katello-package-upload
+exit 0
+
 %postun
 %if 0%{?fedora} > 18 || 0%{?rhel} > 6
     if systemctl status goferd | grep 'active (running)'; then


### PR DESCRIPTION
So katello gets immediately updated with katello-agent
package status.
