### PR TITLE
fixes #14306 - fail without preupgrade run

### DIFF
--- a/katello/katello.spec
+++ b/katello/katello.spec
@@ -63,6 +63,18 @@ Requires: lsof
 Requires: postgresql
 Requires: postgresql-server
 
+%pre
+if [ $1 -gt 1 ] # Pre script is passed 2 in an upgrade situation, see https://fedoraproject.org/wiki/Packaging:Scriptlets
+then
+  # Users must run the pre-upgrade script for 3.0. TODO: Remove this
+  if [ ! -f /var/lib/foreman/3.0_upgrade_ready ]
+  then
+    echo "You MUST upgrade to the latest 2.4 release, and execute the pre-upgrade script. See http://www.katello.org/docs/3.0/upgrade/index.html for more information."
+    exit 1
+  fi
+fi
+
+
 %description
 Provides a package for managing application life-cycle for Linux systems.
 


### PR DESCRIPTION
We will ship a pre-upgrade script with 2.4. that needs to be run before
upgrading to 3.0 GA.  This should cause the yum transaction to fail
out entirely, and let the user know they need to run the preupgrade
before they can continue.  Remove in 3.1.
