### PR TITLE
Fixes #15230 - Require newer katello-service

### DIFF
--- a/katello-installer/katello-installer-base.spec
+++ b/katello-installer/katello-installer-base.spec
@@ -27,7 +27,7 @@ Group:	 Applications/System
 Obsoletes: katello-installer
 Obsoletes: capsule-installer
 Requires: %{name} = %{version}-%{release}
-Requires: katello-service
+Requires: katello-service >= 3.0.0
 
 %description -n foreman-installer-katello
 A set of tools for installation of Katello and and Capsule.


### PR DESCRIPTION
Otherwise upgrading of older version fails

```
Upgrading...
Upgrade Step: stop_services...
Upgrade Step: start_databases...
Upgrade step start_databases failed. Check logs for more information.
```

since it uses `katello-service start --only mongod,postgresql`, older version does not have the support for `--only`
