### PR TITLE
Fixes #15299 - preserve legacy config during upgrade

### DIFF
--- a/katello-installer/katello-installer-base.spec
+++ b/katello-installer/katello-installer-base.spec
@@ -32,7 +32,11 @@ Requires: katello-service >= 3.0.0
 %description -n foreman-installer-katello
 A set of tools for installation of Katello and and Capsule.
 
-%post -n foreman-installer-katello
+%posttrans -n foreman-installer-katello
+mv /etc/katello-installer/katello-installer.yaml.rpmsave /etc/katello-installer/katello-installer.yaml >/dev/null 2>&1 || :
+mv /etc/capsule-installer/capsule-installer.yaml.rpmsave /etc/capsule-installer/capsule-installer.yaml >/dev/null 2>&1 || :
+mv /etc/katello-installer/answers.katello-installer.yaml.rpmsave /etc/katello-installer/answers.katello-installer.yaml >/dev/null 2>&1 || :
+mv /etc/capsule-installer/answers.capsule-installer.yaml.rpmsave /etc/capsule-installer/answers.capsule-installer.yaml >/dev/null 2>&1 || :
 foreman-installer --scenario katello --migrations-only > /dev/null
 foreman-installer --scenario capsule --migrations-only > /dev/null
 
@@ -61,7 +65,9 @@ Requires:  %{name} = %{version}-%{release}
 A set of tools for installation of a Katello development environment using
 Katello and Foreman from git.
 
-%post -n foreman-installer-katello-devel
+%posttrans -n foreman-installer-katello-devel
+mv /etc/katello-devel-installer/katello-devel-installer.yaml.rpmsave /etc/katello-devel-installer/katello-devel-installer.yaml >/dev/null 2>&1 || :
+mv /etc/katello-devel-installer/answers.katello-devel-installer.yaml.rpmsave /etc/katello-devel-installer/answers.katello-devel-installer.yaml >/dev/null 2>&1 || :
 foreman-installer --scenario katello-devel --migrations-only > /dev/null
 
 %files -n foreman-installer-katello-devel


### PR DESCRIPTION
The legacy config files are renamed to `.rpmsave` during yum update and migration script is unable to locate them. This patch is renaming the files back before migration.

I also moved calling installer migrations to `%posttrans` which is more practical and allows other packages to extend the migrations.
