### PR TITLE
Fixes #16028 - Ignoring proxy when pinging services

### DIFF
--- a/katello/service-wait
+++ b/katello/service-wait
@@ -43,7 +43,7 @@ wait_for_url() {
 
   while [[ $RETVAL -ne 0 && $tries -lt $WAIT_MAX ]]; do
     tries=$((tries + 1))
-    /usr/bin/curl -ks $1 > /dev/null
+    /usr/bin/curl -ks --noproxy '*' $1 > /dev/null
     RETVAL=$?
     sleep $RETRY_INTERVAL
   done


### PR DESCRIPTION
Same change basically as https://git.io/v6csS. During upgrades, [the installer calls this line to ping tomcat](https://git.io/v6ccw) and we're seeing upgrades fail if `$https_proxy` is set.
