### PR TITLE
Refs #13017 - cleanup qpid from comps

### DIFF
--- a/comps/comps-katello-pulp-server-rhel6.xml
+++ b/comps/comps-katello-pulp-server-rhel6.xml
@@ -65,25 +65,11 @@
        <packagereq type="default">python-gofer-qpid</packagereq>
        <packagereq type="default">python-gofer-amqp</packagereq>
        <packagereq type="default">python-gofer-proton</packagereq>
-       <packagereq type="default">python-qpid</packagereq>
-       <packagereq type="default">python-qpid-common</packagereq>
-       <packagereq type="default">python-qpid-qmf</packagereq>
        <packagereq type="default">python-requests-toolbelt</packagereq>
        <packagereq type="default">python-rhsm</packagereq>
        <packagereq type="default">python-semantic_version</packagereq>
        <packagereq type="default">python-saslwrapper</packagereq>
        <packagereq type="default">python-webpy</packagereq>
-       <packagereq type="default">qpid-cpp-client</packagereq>
-       <packagereq type="default">qpid-cpp-client-devel</packagereq>
-       <packagereq type="default">qpid-cpp-server</packagereq>
-       <packagereq type="default">qpid-cpp-server-linearstore</packagereq>
-       <packagereq type="default">qpid-proton-c</packagereq>
-       <packagereq type="default">python-qpid-proton</packagereq>
-       <packagereq type="default">qpid-dispatch-router</packagereq>
-       <packagereq type="default">qpid-dispatch-tools</packagereq>
-       <packagereq type="default">libqpid-dispatch</packagereq>
-       <packagereq type="default">qpid-qmf</packagereq>
-       <packagereq type="default">qpid-tools</packagereq>
        <packagereq type="default">saslwrapper</packagereq>
     </packagelist>
   </group>

--- a/comps/comps-katello-pulp-server-rhel7.xml
+++ b/comps/comps-katello-pulp-server-rhel7.xml
@@ -70,23 +70,9 @@
        <packagereq type="default">python-gofer-qpid</packagereq>
        <packagereq type="default">python-gofer-amqp</packagereq>
        <packagereq type="default">python-gofer-proton</packagereq>
-       <packagereq type="default">python-qpid</packagereq>
-       <packagereq type="default">python-qpid-common</packagereq>
-       <packagereq type="default">python-qpid-qmf</packagereq>
        <packagereq type="default">python-requests-toolbelt</packagereq>
        <packagereq type="default">python-saslwrapper</packagereq>
        <packagereq type="default">python-webpy</packagereq>
-       <packagereq type="default">qpid-cpp-client</packagereq>
-       <packagereq type="default">qpid-cpp-client-devel</packagereq>
-       <packagereq type="default">qpid-cpp-server</packagereq>
-       <packagereq type="default">qpid-cpp-server-linearstore</packagereq>
-       <packagereq type="default">qpid-proton-c</packagereq>
-       <packagereq type="default">python-qpid-proton</packagereq>
-       <packagereq type="default">qpid-dispatch-router</packagereq>
-       <packagereq type="default">qpid-dispatch-tools</packagereq>
-       <packagereq type="default">libqpid-dispatch</packagereq>
-       <packagereq type="default">qpid-qmf</packagereq>
-       <packagereq type="default">qpid-tools</packagereq>
        <packagereq type="default">saslwrapper</packagereq>
     </packagelist>
   </group>

--- a/comps/comps-katello-server-rhel6.xml
+++ b/comps/comps-katello-server-rhel6.xml
@@ -47,6 +47,16 @@
        <packagereq type="default">tfm-rubygem-terminal-table</packagereq>
        <packagereq type="default">tfm-rubygem-qpid_messaging</packagereq>
        <packagereq type="default">tfm-rubygem-hammer_cli_csv</packagereq>
+
+       <!-- katello thirdparty non-rubygem packages -->
+       <packagereq type="default">python-urllib3</packagereq>
+
+       <!-- temporary qpid packages -->
+       <packagereq type="default">qpid-dispatch-router</packagereq>
+       <packagereq type="default">qpid-dispatch-tools</packagereq>
+       <packagereq type="default">python-qpid-proton</packagereq>
+       <packagereq type="default">qpid-proton-c</packagereq>
+       <packagereq type="default">qpid-proton-cpp</packagereq>
     </packagelist>
   </group>
   <group>

--- a/comps/comps-katello-server-rhel7.xml
+++ b/comps/comps-katello-server-rhel7.xml
@@ -48,6 +48,13 @@
        <packagereq type="default">tfm-rubygem-terminal-table</packagereq>
        <packagereq type="default">tfm-rubygem-qpid_messaging</packagereq>
        <packagereq type="default">tfm-rubygem-hammer_cli_csv</packagereq>
+
+       <!-- katello thirdparty non-rubygem packages -->
+       <packagereq type="default">python-urllib3</packagereq>
+
+       <!-- temporary qpid packages -->
+       <packagereq type="default">qpid-dispatch-router</packagereq>
+       <packagereq type="default">qpid-dispatch-tools</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
some qpid packages are still required, but since
they are only dispatch router related moving those
to katello repo
