### PR TITLE
fixes #16373 - include rex services in katello-service

### DIFF
--- a/katello/katello-service
+++ b/katello/katello-service
@@ -5,20 +5,21 @@ require 'optparse'
 ACTIONS = ['restart', 'stop', 'start', 'status', 'list']
 COMMAND = '/usr/sbin/service-wait'
 SERVICES = {
-  'mongod'                => 5,
-  'postgresql'            => 5,
-  'qpidd'                 => 10,
-  'qdrouterd'             => 10,
-  'squid'                 => 10,
-  'tomcat'                => 20,
-  'tomcat6'               => 20,
-  'pulp_workers'          => 20,
-  'pulp_celerybeat'       => 20,
-  'pulp_resource_manager' => 20,
-  'pulp_streamer'         => 20,
-  'foreman-proxy'         => 20,
-  'httpd'                 => 30,
-  'foreman-tasks'         => 30
+  'mongod'                   => 5,
+  'postgresql'               => 5,
+  'qpidd'                    => 10,
+  'qdrouterd'                => 10,
+  'squid'                    => 10,
+  'tomcat'                   => 20,
+  'tomcat6'                  => 20,
+  'pulp_workers'             => 20,
+  'pulp_celerybeat'          => 20,
+  'pulp_resource_manager'    => 20,
+  'pulp_streamer'            => 20,
+  'foreman-proxy'            => 20,
+  'smart_proxy_dynflow_core' => 20,
+  'httpd'                    => 30,
+  'foreman-tasks'            => 30
 }
 
 @options = {:excluded => []}

--- a/katello/katello-service-bash_completion.sh
+++ b/katello/katello-service-bash_completion.sh
@@ -1,7 +1,7 @@
 # Opts for every command
 _katelloservice_help_opts="-h --help"
 _katello_action_opts="restart stop start status list"
-_katello_services="mongod postgresql qpidd qdrouterd squid tomcat tomcat6 pulp_workers pulp_celerybeat pulp_resource_manager pulp_streamer foreman-proxy httpd foreman-tasks"
+_katello_services="mongod postgresql qpidd qdrouterd squid tomcat tomcat6 pulp_workers pulp_celerybeat pulp_resource_manager pulp_streamer foreman-proxy smart_proxy_dynflow_core httpd foreman-tasks"
 
 _katello-service_exclude-only()
 {


### PR DESCRIPTION
Katello service checks to see if a service is existent before it tries
to do anything with it, so I think it's worthwhile to include
smart_proxy_dynflow_core in it's list.
