### PR TITLE
 Make sure katello-backup does not override permissions for existing directories

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -42,6 +42,12 @@ if @dir.nil?
   puts "**** ERROR: Please specify an export directory ****"
   puts optparse
   exit(-1)
+end
+
+if Dir.exist?(@dir)
+  puts "**** ERROR: Directory already exists. Please specify a new export directory ****"
+  puts optparse
+  exit(-1)
 else
   @time = Time.now
   puts "Starting backup: #{@time}"


### PR DESCRIPTION
This patch fixes katello-backup to avoid to override permissions from directories that already exists on the system. 

For instance, if the user by mistake type `katello-backup /tmp`, the `/tmp` permissions will override to 0770 causing a lot of issues on the system. 

``` bash
# ./katello-backup /tmp
**** ERROR: Directory already exists. Please specify a new export directory ****
Usage: katello-backup /path/to/dir [options]
 eg: $ katello-backup /tmp/katello-backup
        --skip-pulp-content          Create backup without Pulp content
        --incremental [PREVIOUS_BACKUP_DIR]
                                     Backup changes since previous backup
        --online-backup              Keep services online during backup
```
