### PR TITLE
fixes #16655 - remove clean puppet envs script

### DIFF
--- a/katello/katello-clean-empty-puppet-environments
+++ b/katello/katello-clean-empty-puppet-environments
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Puppet 4
-[ -d /etc/puppetlabs/code/environments ] &&  find /etc/puppetlabs/code/environments/KT* -maxdepth 0 -type d -empty -delete
-
-# Puppet 3
-[ -d /etc/puppet/environments ] && find /etc/puppet/environments/KT* -maxdepth 0 -type d -empty -delete

--- a/katello/katello.spec
+++ b/katello/katello.spec
@@ -23,7 +23,6 @@ Source6:    katello-restore
 Source7:    katello-backup
 Source8:    katello-service-bash_completion.sh
 Source9:    qpid-core-dump
-Source10:   katello-clean-empty-puppet-environments 
 
 BuildRequires: asciidoc
 BuildRequires: util-linux
@@ -80,7 +79,6 @@ mkdir -p %{buildroot}/%{_mandir}/man8
 #copy cron scripts to be scheduled
 install -d -m0755 %{buildroot}%{_sysconfdir}/cron.weekly
 install -m 755 %{SOURCE3} %{buildroot}%{_sysconfdir}/cron.weekly/katello-remove-orphans
-install -m 755 %{SOURCE10} %{buildroot}%{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
 
 # install important scripts
 mkdir -p %{buildroot}%{_bindir}
@@ -127,7 +125,6 @@ Common runtime components of %{name}
 %{_bindir}/katello-backup
 %{_bindir}/katello-restore
 %{_bindir}/qpid-core-dump
-%config(missingok) %{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
 %config(missingok) %{_sysconfdir}/cron.weekly/katello-remove-orphans
 
 # ------ Debug ----------------
@@ -152,7 +149,6 @@ Requires: foreman-installer-%{name}
 Provides a federation of katello services
 
 %files capsule
-%config(missingok) %{_sysconfdir}/cron.weekly/katello-clean-empty-puppet-environments
 
 # ------ Service ----------------
 %package service


### PR DESCRIPTION
This can remove directory environments that while empty have hosts assigned to them in Foreman, breaking clients and generating error reports in Foreman.

What do we do about the katello-capsule package? Obsolete it?
