### PR TITLE
Fixes #16251 - Add katello-service disable/enable options

### DIFF
--- a/katello/katello-service
+++ b/katello/katello-service
@@ -2,7 +2,7 @@
 
 require 'optparse'
 
-ACTIONS = ['restart', 'stop', 'start', 'status', 'list']
+ACTIONS = ['restart', 'stop', 'start', 'status', 'list', 'enable', 'disable']
 COMMAND = '/usr/sbin/service-wait'
 SERVICES = {
   'mongod'                   => 5,
@@ -50,7 +50,7 @@ end
 
 def service_exists?(service)
   upstart = File.exist?("/etc/init.d/#{service}")
-  systemd = `systemctl is-enabled #{service} 2>&1` && $?.success?
+  systemd = `systemctl cat #{service} 2>&1` && $?.success?
   upstart || systemd
 end
 

--- a/katello/katello-service-bash_completion.sh
+++ b/katello/katello-service-bash_completion.sh
@@ -1,7 +1,7 @@
 # Opts for every command
 _katelloservice_help_opts="-h --help"
-_katello_action_opts="restart stop start status list"
-_katello_services="mongod postgresql qpidd qdrouterd squid tomcat tomcat6 pulp_workers pulp_celerybeat pulp_resource_manager pulp_streamer foreman-proxy smart_proxy_dynflow_core httpd foreman-tasks"
+_katello_action_opts="restart stop start status list enable disable"
+_katello_services="mongod postgresql qpidd qdrouterd squid tomcat tomcat6 pulp_workers pulp_celerybeat pulp_resource_manager pulp_streamer foreman-proxy smart_proxy_dynflow_core httpd foreman-tasks goferd"
 
 _katello-service_exclude-only()
 {

--- a/katello/service-wait
+++ b/katello/service-wait
@@ -109,6 +109,22 @@ after_status() {
   test 1 -eq 1 # noop
 }
 
+before_enable() {
+  test 1 -eq 1 # noop
+}
+
+after_enable() {
+  test 1 -eq 1 # noop
+}
+
+before_disable() {
+  test 1 -eq 1 # noop
+}
+
+after_disable() {
+  test 1 -eq 1 # noop
+}
+
 case "$COMMAND" in
   start)
     before_start
@@ -133,6 +149,18 @@ case "$COMMAND" in
     /sbin/service "$SERVICE" "$COMMAND"
     RETVAL=$?
     after_status
+    ;;
+  enable)
+    before_enable
+    /usr/sbin/chkconfig "$SERVICE" on
+    RETVAL=$?
+    after_enable
+    ;;
+  disable)
+    before_disable
+    /usr/sbin/chkconfig "$SERVICE" off
+    RETVAL=$?
+    after_disable
     ;;
   test-wait)
     echo -n "Starting $SERVICE... "


### PR DESCRIPTION
I've also added goferd to the bash_completion script, it was missed from #291 :-)
