### PR TITLE
Make devel installer depend on regular installer

### DIFF
--- a/katello-installer/katello-installer-base.spec
+++ b/katello-installer/katello-installer-base.spec
@@ -60,6 +60,7 @@ foreman-installer --scenario capsule --migrations-only > /dev/null
 Summary:   Installer scenario for Katello development setup from git
 Group:	   Applications/System
 Requires:  %{name} = %{version}-%{release}
+Requires:  foreman-installer-katello
 
 %description -n foreman-installer-katello-devel
 A set of tools for installation of a Katello development environment using


### PR DESCRIPTION
This allows forklift installations to have katello-service, 
katello-certs-check, etc... right off the bat on forklift.

I wasn't sure which branch to PR this to, the original issue https://github.com/Katello/forklift/issues/341 has a link to a fix directly in forklift in case making this dependency would not be appropriate for some reason.