### PR TITLE
Fixes #11607 - Add hammer ping to debug

### DIFF
--- a/katello/katello-debug.sh
+++ b/katello/katello-debug.sh
@@ -125,5 +125,7 @@ echo "db.task_status.find({state:{\$ne: \"finished\"}}).pretty().shellPrint()" >
 
 add_cmd "mongo pulp_database /tmp/pulp_running_tasks.js" "pulp-running_tasks"
 
+add_cmd "hammer ping" "hammer-ping"
+
 # Legend:
 # * - already collected by sosreport tool (skip when -g option was provided)


### PR DESCRIPTION
Adding hammer ping to katello-debug so it gets added to foreman-debug when run.