### PR TITLE
Fixes #18173 - Dont run katello-tracer-upload during install

### DIFF
--- a/katello-agent/katello-agent.spec
+++ b/katello-agent/katello-agent.spec
@@ -1,6 +1,6 @@
 Name: katello-agent
 Version: 2.8.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: The Katello Agent
 Group:   Development/Languages
 License: LGPLv2
@@ -89,10 +89,6 @@ exit 0
 
 %posttrans
 katello-package-upload
-
-%if 0%{?fedora} > 18 || 0%{?rhel} > 6
-katello-tracer-upload
-%endif
 
 exit 0
 


### PR DESCRIPTION
This results in a error because yum has a lock on the RPM DB which katello-tracer-upload needs to run.