### PR TITLE
Fixes #18198 - collect httpd pulp logs in katello-debug

### DIFF
--- a/katello/katello-debug.sh
+++ b/katello/katello-debug.sh
@@ -64,6 +64,8 @@ add_files /var/log/rhsm/*
 add_files /etc/pulp/*.conf
 add_files /etc/httpd/conf.d/pulp.conf
 add_files /etc/pulp/server/plugins.conf.d/nodes/distributor/*
+add_files /var/log/httpd/pulp-http{s,}_access_ssl.log*
+add_files /var/log/httpd/pulp-http{s,}_error_ssl.log*
 
 # MongoDB (*)
 if [ $NOGENERIC -eq 0 ]; then


### PR DESCRIPTION
Collect /var/log/httpd/pulp-http{s,}_{access,error}_ssl.log*

Fixes #18198

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>