### PR TITLE
Fixes #18396 - Collect /etc/default/pulp* items in katello-debug

### DIFF
--- a/katello/katello-debug.sh
+++ b/katello/katello-debug.sh
@@ -66,6 +66,7 @@ add_files /etc/httpd/conf.d/pulp.conf
 add_files /etc/pulp/server/plugins.conf.d/nodes/distributor/*
 add_files /var/log/httpd/pulp-http{s,}_access_ssl.log*
 add_files /var/log/httpd/pulp-http{s,}_error_ssl.log*
+add_files /etc/default/pulp*
 
 # MongoDB (*)
 if [ $NOGENERIC -eq 0 ]; then


### PR DESCRIPTION
Need to at least have pulp_workers collected, wouldn't hurt to have the rest if they ever become relevant past encoding type.