### PR TITLE
Make sure the postgres roles exist before doing the data loads

### DIFF
--- a/katello/katello-restore
+++ b/katello/katello-restore
@@ -44,7 +44,9 @@ def restore_databases
     `tar --selinux --overwrite --listed-incremental=/dev/null -xzf pgsql_data.tar.gz -C /`
   else
     `service postgresql start`
+    `runuser - postgres -c "createuser foreman"`
     `runuser - postgres -c "dropdb foreman"`
+    `runuser - postgres -c "createuser candlepin"`
     `runuser - postgres -c "dropdb candlepin"`
     `runuser - postgres -c "pg_restore -C -d postgres #{DIR}/foreman.dump"`
     `runuser - postgres -c "pg_restore -C -d postgres #{DIR}/candlepin.dump"`


### PR DESCRIPTION
When migrating to a different host, it is helpful to have the roles created in the restore.

On normal restores these new lines have no impact.