### PR TITLE
Modified katello-service to support enable/disable for systemd

### DIFF
--- a/katello/katello-service
+++ b/katello/katello-service
@@ -91,10 +91,9 @@ def manage_services(action)
         puts "#{COMMAND} #{service} #{action}"
         puts `#{COMMAND} #{service} #{action}`
       end
-    end
     failures << service unless $?.success?
+    end
   end
-end
 
   if failures.empty?
     puts "Success!"

--- a/katello/katello-service
+++ b/katello/katello-service
@@ -94,6 +94,7 @@ def manage_services(action)
     end
     failures << service unless $?.success?
   end
+end
 
   if failures.empty?
     puts "Success!"

--- a/katello/katello-service
+++ b/katello/katello-service
@@ -36,10 +36,6 @@ OptionParser.new do |opts|
     @options[:only] = only
   end
 
-  opts.on("-v", "--verbose", "To be used with status, to increase verbosity") do |v|
-    @options[:verbose] = v
-  end
-
   opts.parse!
 
   if ARGV.length == 0 || ARGV.length != 1
@@ -77,18 +73,6 @@ def list_services
   puts `chkconfig --list 2>&1 | grep '#{regex}'`
 end
 
-def status_services(action)
-  if `which systemctl 2>&1` && $?.success? && !(@options.include?(:verbose))
-    regex = services_by_priority.map { |service| "^[^a-z_-]*#{service}.service" }.join('\|')
-    puts `systemctl list-units --all \*.service | grep -e '#{regex}' -e '^ *UNIT'`
-  else
-    services_by_priority.each do |service|
-      puts "#{COMMAND} #{service} #{action}"
-      puts `#{COMMAND} #{service} #{action}`
-    end
-  end
-end
-
 def manage_services(action)
   failures = []
 
@@ -124,8 +108,6 @@ when 'list'
   list_services
 when 'restart'
   %w(stop start).each { |action| manage_services action }
-when 'status'
-  status_services @options[:action]
 else
   manage_services @options[:action]
 end

--- a/katello/katello-service
+++ b/katello/katello-service
@@ -36,6 +36,10 @@ OptionParser.new do |opts|
     @options[:only] = only
   end
 
+  opts.on("-v", "--verbose", "To be used with status, to increase verbosity") do |v|
+    @options[:verbose] = v
+  end
+
   opts.parse!
 
   if ARGV.length == 0 || ARGV.length != 1
@@ -73,6 +77,18 @@ def list_services
   puts `chkconfig --list 2>&1 | grep '#{regex}'`
 end
 
+def status_services(action)
+  if `which systemctl 2>&1` && $?.success? && !(@options.include?(:verbose))
+    regex = services_by_priority.map { |service| "^[^a-z_-]*#{service}.service" }.join('\|')
+    puts `systemctl list-units --all \*.service | grep -e '#{regex}' -e '^ *UNIT'`
+  else
+    services_by_priority.each do |service|
+      puts "#{COMMAND} #{service} #{action}"
+      puts `#{COMMAND} #{service} #{action}`
+    end
+  end
+end
+
 def manage_services(action)
   failures = []
 
@@ -108,6 +124,8 @@ when 'list'
   list_services
 when 'restart'
   %w(stop start).each { |action| manage_services action }
+when 'status'
+  status_services @options[:action]
 else
   manage_services @options[:action]
 end

--- a/katello/katello-service
+++ b/katello/katello-service
@@ -91,7 +91,7 @@ def manage_services(action)
         puts "#{COMMAND} #{service} #{action}"
         puts `#{COMMAND} #{service} #{action}`
       end
-    failures << service unless $?.success?
+      failures << service unless $?.success?
     end
   end
 

--- a/katello/katello-service
+++ b/katello/katello-service
@@ -78,21 +78,21 @@ def manage_services(action)
 
   services_by_priority(action == 'stop').each do |service|
     if service_exists?(service)
-      if `which systemctl 2>&1` && $?.success?
-        puts "systemctl #{action} #{service}.service"
-        puts `systemctl #{action} #{service}.service`
-      else
-        case action
-        when 'enable', 'disable'
+      case action
+      when 'enable', 'disable'
+        if `which systemctl 2>&1` && $?.success?
+          puts "systemctl #{action} #{service}.service"
+          puts `systemctl #{action} #{service}.service`
+        else
           puts "chkconfig #{service} on"
           puts `chkconfig #{service} on`
-        else
-          puts "#{COMMAND} #{service} #{action}"
-          puts `#{COMMAND} #{service} #{action}`
         end
+      else
+        puts "#{COMMAND} #{service} #{action}"
+        puts `#{COMMAND} #{service} #{action}`
       end
-      failures << service unless $?.success?
     end
+    failures << service unless $?.success?
   end
 
   if failures.empty?

--- a/katello/katello-service
+++ b/katello/katello-service
@@ -78,7 +78,19 @@ def manage_services(action)
 
   services_by_priority(action == 'stop').each do |service|
     if service_exists?(service)
-      puts `#{COMMAND} #{service} #{action}`
+      if `which systemctl 2>&1` && $?.success?
+        puts "systemctl #{action} #{service}.service"
+        puts `systemctl #{action} #{service}.service`
+      else
+        case action
+        when 'enable', 'disable'
+          puts "chkconfig #{service} on"
+          puts `chkconfig #{service} on`
+        else
+          puts "#{COMMAND} #{service} #{action}"
+          puts `#{COMMAND} #{service} #{action}`
+        end
+      end
       failures << service unless $?.success?
     end
   end


### PR DESCRIPTION
Changes in PR #306 lay ground work for enable/disable support.  However, when enable/disable is invoked on a systemd system, it parses the command as "service-wait #{service} #{action}".  Thus, I modified the manage_services method to utilize systemctl and chkconfig where necessary.  It's crude, but it works.  Not a dev.