### PR TITLE
Run the tar compression in parallel

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -80,8 +80,10 @@ def backup_pulp_offline
 end
 
 def compress_files
-  `gzip pgsql_data.tar`
-  `gzip mongo_data.tar`
+  psql = spawn('gzip', 'pgsql_data.tar')
+  mongo = spawn('gzip', 'mongo_data.tar')
+  Process.wait(psql)
+  Process.wait(mongo)
 end
 
 if @dir.nil?


### PR DESCRIPTION
I believe this should allow the compression of the postgres/mongo tar files to happen in parallel and thus a bit faster.