### PR TITLE
Update katello-repos.spec so that repo files are config files

### DIFF
--- a/repos/katello-repos.spec
+++ b/repos/katello-repos.spec
@@ -33,9 +33,9 @@ Defines yum repositories for Katello clients.
 
 %files -n katello-client-repos
 %defattr(-, root, root)
-%{_sysconfdir}/yum.repos.d/katello-client.repo
+%config %{_sysconfdir}/yum.repos.d/katello-client.repo
 %if 0%{?rhel} == 6
-%{_sysconfdir}/yum.repos.d/qpid-copr.repo
+%config %{_sysconfdir}/yum.repos.d/qpid-copr.repo
 %endif
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-katello
 
@@ -74,7 +74,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-, root, root)
-%{_sysconfdir}/yum.repos.d/*.repo
+%config %{_sysconfdir}/yum.repos.d/*.repo
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-katello
 
 %changelog


### PR DESCRIPTION
If you update the .repo files, for example to disable repositories because you have them mirrored locally (self registered katello) an update will simply overwrite the changes. if you have them marked as config files you get a warning about the rpmnew/rpmsave files while updating.

someone please test it, I don't have an rpmbuild environment handy at the moment :)