### PR TITLE
Fixes #18266 - remove old certs in pub/ on hostname change

### DIFF
--- a/katello/katello-change-hostname
+++ b/katello/katello-change-hostname
@@ -166,6 +166,8 @@ end
 STDOUT.puts "stopping services"
 `katello-service stop`
 
+public_dir = "/var/www/html/pub"
+public_backup_dir = "#{public_dir}/#{old_hostname}-#{timestamp}.backup"
 STDOUT.puts "deleting old certs"
 `
 rm -rf #{scenario_answers["certs"]["pki_dir"]}{,.bak}
@@ -187,8 +189,11 @@ rm -f /etc/tomcat/keystore
 rm -f /etc/pki/katello/keystore
 cp -r #{ssl_build_dir} #{ssl_backup_dir}
 rm -rf #{ssl_build_dir}
+mkdir #{public_backup_dir}
+mv #{public_dir}/*.rpm #{public_backup_dir}
 `
 STDOUT.puts "backed up #{ssl_build_dir} to #{ssl_backup_dir}"
+STDOUT.puts "backed up #{public_dir} to #{public_backup_dir}"
 STDOUT.puts "updating hostname in /etc/hosts"
 `sed -i -e 's/#{old_hostname}/#{new_hostname}/g' /etc/hosts`
 


### PR DESCRIPTION
Before hostname change:
[root@centos7-katello-3-3 ~]# ls /var/www/html/pub/
bootstrap.py
bootstrap.pyo
bootstrap.pyc
katello-ca-consumer-centos7-katello-3-3.example.com-1.0-1.src.rpm
katello-ca-consumer-centos7-katello-3-3.example.com-1.0-1.noarch.rpm
katello-ca-consumer-latest.noarch.rpm
katello-server-ca.crt
katello-rhsm-consumer

After hostname change
[root@centos7-katello-3-3 ~]# ls /var/www/html/pub/
bootstrap.py
bootstrap.pyc
bootstrap.pyo
centos7-katello-3-3.example.com-201703071758.backup <--- backup directory
katello-ca-consumer-foo.example.com-1.0-1.noarch.rpm
katello-ca-consumer-foo.example.com-1.0-1.src.rpm
katello-ca-consumer-latest.noarch.rpm
katello-rhsm-consumer
katello-server-ca.crt

certs with old hostname are in a backup directory in /var/www/html/pub
ls /var/www/html/pub/centos7-katello-3-3.example.com-201703071758.backup/
katello-ca-consumer-centos7-katello-3-3.example.com-1.0-1.noarch.rpm
katello-ca-consumer-centos7-katello-3-3.example.com-1.0-1.src.rpm
katello-ca-consumer-latest.noarch.rpm -> /var/www/html/pub/katello-ca