### PR TITLE
Refs #18403 - Regenerate ueber certs after hostname change

### DIFF
--- a/katello/katello-change-hostname
+++ b/katello/katello-change-hostname
@@ -214,6 +214,9 @@ installer_output = `#{installer}`
 installer_success = $?.success?
 STDOUT.puts installer_output
 
+STDOUT.puts "Regenerating ueber certs"
+`foreman-rake katello:regenerate_ueber_certs`
+
 if installer_success
   STDOUT.puts "
   Hostname change complete!


### PR DESCRIPTION
Depends on https://github.com/Katello/katello/pull/6680

Since we regenerate the CA, we need to regenerate the
ueber cert for each Organization.