### PR TITLE
Fixes #18965 - exclude unnecessary services

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -7,6 +7,8 @@ require 'date'
 @options = {}
 @dir = nil
 
+EXCLUDED="--exclude goferd,foreman-proxy,squid,smart_proxy_dynflow_core,qdrouterd,qpidd"
+
 optparse = OptionParser.new do |opts|
   opts.banner = "Usage: katello-backup /path/to/dir [options]\n eg: $ katello-backup /tmp/katello-backup"
 
@@ -156,10 +158,10 @@ else
     if @options[:logical_backup]
         backup_db_online
     end
-    `katello-service stop`
+    `katello-service stop #{EXCLUDED}`
     backup_db_offline
     backup_pulp_offline unless @options[:config_only]
-    `katello-service start`
+    `katello-service start #{EXCLUDED}`
     compress_files
   end
 


### PR DESCRIPTION
The script does not touch these, goferd is leaking memory when connection is lost, let's not poke it when not necessary.