### PR TITLE
Fixes #19038 - After katello-agent installation goferd is not started

### DIFF
--- a/katello-agent/katello-agent.spec
+++ b/katello-agent/katello-agent.spec
@@ -89,6 +89,7 @@ rm -rf %{buildroot}
 
 %post
 chkconfig goferd on
+systemctl start goferd > /dev/null 2>&1
 touch /tmp/katello-agent-restart
 exit 0
 


### PR DESCRIPTION
Have goferd start in %post

Originally I had no realized that systemctl restart also will start a process that is off.  This will fix the regression and keep the fix that caused the regression. 