### PR TITLE
Fixes #18333 run_cmd takes exit status args

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -46,9 +46,9 @@ optparse = OptionParser.new do |opts|
   @dir = ARGV[0].dup
 end
 
-def run_cmd(command)
+def run_cmd(command, exit_codes=[0])
   `#{command}`
-  if $?.exitstatus != 0
+  unless exit_codes.include?($?.exitstatus)
     STDERR.puts "Failed '#{command}'"
     exit(-1)
   end
@@ -154,7 +154,7 @@ else
   end
 
   puts "Backing up config files... "
-  run_cmd("tar --selinux --create --gzip --file=config_files.tar.gz --listed-incremental=.config.snar #{CONFIGS.join(' ')} 2>/dev/null")
+  run_cmd("tar --selinux --create --gzip --file=config_files.tar.gz --listed-incremental=.config.snar #{CONFIGS.join(' ')} 2>/dev/null", [0,2])
   puts "Done."
 
   `shopt -s dotglob ; cp #{@options[:incremental]}/*.snar .` if @options[:incremental]


### PR DESCRIPTION
This is a followup patch for #18333.

The if condition is a bit ugly, but I believe it gets the job done.