### PR TITLE
Fixes #19054 - Use a timestamp without special characters in kbackup

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -112,7 +112,7 @@ if @dir.nil?
   exit(-1)
 else
   @dir << "/" unless @dir.end_with? "/"
-  @dir << "katello-backup-" + DateTime.now.to_s
+  @dir << "katello-backup-" + DateTime.now.strftime('%Y%m%d%H%M%S')
   puts "Starting backup: #{Time.now}"
   FileUtils.mkdir_p(@dir)
   puts "Creating backup folder #{@dir}"


### PR DESCRIPTION
These special characters can cause issues for programs, the
timestamp will now read 20170328172811, allowing the files
to still be sorted by date.