### PR TITLE
fixes #18329 - adds LVM snapshots to backup

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -3,24 +3,52 @@
 require 'optparse'
 require 'fileutils'
 require 'date'
-require "yaml"
+require 'yaml'
+require 'find'
+
+EXCLUDED="--exclude goferd,foreman-proxy,squid,smart_proxy_dynflow_core,qdrouterd,qpidd"
+DATABASES = ['pulp', 'pgsql', 'mongodb']
+CONFIGS = [
+  '/etc/candlepin',
+  '/etc/foreman',
+  '/etc/foreman-proxy',
+  '/etc/hammer',
+  '/etc/httpd',
+  '/etc/foreman-installer',
+  '/etc/pki/katello',
+  '/etc/pki/katello-certs-tools',
+  '/etc/pki/pulp',
+  '/etc/pulp',
+  '/etc/puppet',
+  '/etc/puppetlabs',
+  '/etc/qpid',
+  '/etc/qpid-dispatch',
+  '/etc/sysconfig/tomcat*',
+  '/etc/tomcat*',
+  '/root/ssl-build',
+  '/var/lib/candlepin',
+  '/var/www/html/pub',
+  '/opt/puppetlabs/puppet/cache/foreman_cache_data',
+  '/opt/puppetlabs/puppet/ssl',
+  '/var/lib/puppet/foreman_cache_data',
+  '/var/lib/puppet/ssl'
+]
 
 @options = {}
 @dir = nil
-
-EXCLUDED="--exclude goferd,foreman-proxy,squid,smart_proxy_dynflow_core,qdrouterd,qpidd"
+@databases = DATABASES.dup
 
 optparse = OptionParser.new do |opts|
   opts.banner = "Usage: katello-backup /path/to/dir [options]\n eg: $ katello-backup /tmp/katello-backup"
 
   opts.on("--skip-pulp-content", "Create backup without Pulp content for debugging only") do |config_only|
     @options[:config_only] = config_only
+    @databases.delete 'pulp'
   end
 
-  opts.on("--incremental [PREVIOUS_BACKUP_DIR]", String, "Backup changes since previous backup") do |dir_path|
+  opts.on("--incremental PREVIOUS_BACKUP_DIR", String, "Backup changes since previous backup") do |dir_path|
     opts.abort("Please specify the previous backup directory.") unless dir_path
     if File.directory?(dir_path)
-      dir_path.chop! if dir_path.end_with? "/"
       @options[:incremental] = dir_path
     else
       opts.abort("Previous backup directory does not exist: #{dir_path}")
@@ -33,6 +61,18 @@ optparse = OptionParser.new do |opts|
 
   opts.on("--logical-db-backup", "Also dump full database schema during offline backup") do |logical|
     @options[:logical_backup] = logical
+  end
+
+  opts.on("--snapshot", "Use snapshots of the databases to create backup") do |snapshot|
+    @options[:snapshot] = snapshot
+  end
+
+  opts.on("--snapshot-mount-dir SNAPSHOT_MOUNT_LOCATION", String, "Override default directory (/var/snap/) where the snapshots will be mounted") do |mount_dir|
+    @options[:snapshot_mount] = mount_dir
+  end
+
+  opts.on("--snapshot-size SNAPSHOT_BLOCK_DEVICE_SIZE", String, "Override default block size (2G)") do |size|
+    @options[:snapshot_size] = size
   end
 
   opts.parse!
@@ -48,11 +88,12 @@ optparse = OptionParser.new do |opts|
 end
 
 def run_cmd(command, exit_codes=[0])
-  `#{command}`
+  result = `#{command}`
   unless exit_codes.include?($?.exitstatus)
     STDERR.puts "Failed '#{command}'"
     exit(-1)
   end
+  result
 end
 
 def create_directories(directory)
@@ -63,59 +104,128 @@ def create_directories(directory)
   FileUtils.chmod_R 0770, directory
 end
 
-def backup_db_online
-  puts "Backing up postgres online schema... "
-  run_cmd("runuser - postgres -c 'pg_dumpall -g > #{@dir}/pg_globals.dump'")
-  run_cmd("runuser - postgres -c 'pg_dump -Fc foreman > #{@dir}/foreman.dump'")
-  run_cmd("runuser - postgres -c 'pg_dump -Fc candlepin > #{@dir}/candlepin.dump'")
-  puts "Done."
-
-  puts "Backing up mongo online schema... "
-  run_cmd('mongodump --host localhost --out mongo_dump')
-  puts "Done."
+def snapshot_backup
+  @mountdir = @options[:snapshot_mount] || "/var/snap"
+  @snapsize = @options[:snapshot_size] || "2G"
+  FileUtils.mkdir_p @mountdir
+  run_cmd("katello-service stop #{EXCLUDED}")
+  create_and_mount_snapshots
+  run_cmd("katello-service start #{EXCLUDED}")
+  backup_and_destroy_snapshots
 end
 
-def backup_pulp_online
-  puts "Backing up Pulp data... "
-  matching = false
- 
-  until matching
-    checksum1 = `find /var/lib/pulp -printf '%T@\n' | md5sum`
-    create_pulp_data_tar
-    checksum2 = `find /var/lib/pulp -printf '%T@\n' | md5sum`
-    matching = (checksum1 == checksum2)
+def create_and_mount_snapshots
+  @databases.each do |database|
+    puts "Creating #{database} snapshot"
+    lv_info = get_lv_info(database)
+    run_cmd("lvcreate -n#{database}-snap -L#{@snapsize} -s #{lv_info[0]}")
+
+    mount_location = File.join(@mountdir, database)
+    FileUtils.mkdir_p mount_location
+    puts "Mounting #{database} snapshot on #{mount_location}"
+    options = lv_info[1] == 'xfs' ? "-onouuid,ro" : "-oro"
+    run_cmd("mount #{get_snapshot_location(database)} #{mount_location} #{options}")
   end
-  puts "Done."
 end
 
-def backup_db_offline
-  puts "Backing up postgres db... "
-  run_cmd('tar --selinux --create --file=pgsql_data.tar --listed-incremental=.postgres.snar /var/lib/pgsql/data/')
-  puts "Done."
-
-  puts "Backing up mongo db... "
-  run_cmd('tar --selinux --create --file=mongo_data.tar --listed-incremental=.mongo.snar --exclude=mongod.lock /var/lib/mongodb/')
-  puts "Done."
+def get_snapshot_location(database)
+  run_cmd("lvs --noheadings -o lv_path -S lv_name=#{database}-snap").strip
 end
 
-def backup_pulp_offline
-  puts "Backing up Pulp data... "
-  create_pulp_data_tar
-  puts "Done."
+def get_lv_info(database)
+  target = database
+  target = File.join(database, 'data') if target == 'pgsql'
+  run_cmd("findmnt -n --target #{File.join('/var/lib', target)} -o SOURCE,FSTYPE").split
 end
 
-def create_pulp_data_tar
-  run_cmd('tar --selinux --create --file=pulp_data.tar --exclude=/var/lib/pulp/katello-export --listed-incremental=.pulp.snar /var/lib/pulp/')
+def get_base_directory(database)
+  target = ""
+  case database
+  when 'pulp'
+    target = '0005_puppet_module_name_change.txt'
+  when 'pgsql'
+    target = 'postgresql.conf'
+  when 'mongodb'
+    target = 'mongod.lock'
+  end
+
+  result = nil
+  Find.find(File.join(@mountdir, database)) do |path|
+    result = File.dirname(path) if File.basename(path) == target
+  end
+  result
 end
 
-def compress_files
-  psql = spawn('gzip', 'pgsql_data.tar')
-  mongo = spawn('gzip', 'mongo_data.tar')
-  Process.wait(psql)
-  Process.wait(mongo)
+def backup_and_destroy_snapshots
+  @databases.each do |database|
+    basedir = get_base_directory(database)
+    puts "Backing up #{database} from #{basedir}"
+    offline_backup(database, basedir)
+
+    puts "Unmounting #{database} snapshot"
+    run_cmd("umount #{File.join(@mountdir, database)}")
+
+    snapshot_location = get_snapshot_location(database)
+    puts "Removing snapshot #{snapshot_location}"
+    run_cmd("lvremove -f #{snapshot_location}")
+  end
+end
+
+def online_backup(database)
+  case database
+  when 'pulp'
+    FileUtils.cd '/var/lib/pulp' do
+      puts "Backing up Pulp data... "
+      matching = false
+      until matching
+        checksum1 = `find . -printf '%T@\n' | md5sum`
+        create_pulp_data_tar
+        checksum2 = `find . -printf '%T@\n' | md5sum`
+        matching = (checksum1 == checksum2)
+      end
+    end
+    puts "Done."
+  when 'pgsql'
+    puts "Backing up postgres online schema... "
+    run_cmd("runuser - postgres -c 'pg_dumpall -g > #{File.join(@dir, 'pg_globals.dump')}'")
+    run_cmd("runuser - postgres -c 'pg_dump -Fc foreman > #{File.join(@dir, 'foreman.dump')}'")
+    run_cmd("runuser - postgres -c 'pg_dump -Fc candlepin > #{File.join(@dir, 'candlepin.dump')}'")
+    puts "Done."
+  when 'mongodb'
+    puts "Backing up mongo online schema... "
+    run_cmd("mongodump --host localhost --out #{File.join(@dir, 'mongo_dump')}")
+    puts "Done."
+  end
+end
+
+def offline_backup(database, dir_path = nil)
+  case database
+  when 'pulp'
+    dir_path ||= '/var/lib/pulp'
+    FileUtils.cd dir_path do
+      puts "Backing up Pulp data... "
+      create_pulp_data_tar
+      puts "Done."
+    end
+  when 'mongodb'
+    dir_path ||= '/var/lib/mongodb'
+    FileUtils.cd dir_path do
+      puts "Backing up mongo db... "
+      run_cmd("tar --selinux --create --file=#{File.join(@dir, 'mongo_data.tar')} --listed-incremental=#{File.join(@dir, '.mongo.snar')} --exclude=mongod.lock --transform 's,^,var/lib/mongodb/,S' -S *")
+      puts "Done."
+    end
+  when 'pgsql'
+    dir_path ||= '/var/lib/pgsql/data'
+    FileUtils.cd dir_path do
+      puts "Backing up postgres db..."
+      run_cmd("tar --selinux --create --file=#{File.join(@dir, 'pgsql_data.tar')} --listed-incremental=#{File.join(@dir, '.postgres.snar')} --transform 's,^,var/lib/pgsql/data/,S' -S *")
+      puts "Done."
+    end
+  end
 end
 
 def generate_metadata
+  puts "Generating metadata ... "
   os_version = `cat /etc/redhat-release`.chomp
   plugin_list = `foreman-rake plugin:list | grep 'Foreman plugin: '`.lines
   plugins = []
@@ -128,6 +238,24 @@ def generate_metadata
   File.open('metadata.yml', 'w') do |metadata_file|
     metadata_file.puts system_facts.to_yaml
   end
+  puts "Done."
+end
+
+def create_pulp_data_tar
+  run_cmd("tar --selinux --create --file=#{File.join(@dir, 'pulp_data.tar')} --exclude=var/lib/pulp/katello-export --listed-incremental=#{File.join(@dir, '.pulp.snar')} --transform 's,^,var/lib/pulp/,S' -S *")
+end
+
+def backup_config_files
+  puts "Backing up config files... "
+  run_cmd("tar --selinux --create --gzip --file=#{File.join(@dir, 'config_files.tar.gz')} --listed-incremental=#{File.join(@dir, '.config.snar')} #{CONFIGS.join(' ')} 2>/dev/null", [0,2])
+  puts "Done."
+end
+
+def compress_files
+  psql = spawn('gzip', File.join(@dir, 'pgsql_data.tar'))
+  mongo = spawn('gzip', File.join(@dir, 'mongo_data.tar'))
+  Process.wait(psql)
+  Process.wait(mongo)
 end
 
 if @dir.nil?
@@ -138,54 +266,31 @@ else
   puts "Starting backup: #{Time.now}"
   create_directories(@dir.dup)
   FileUtils.cd @dir
-
-  CONFIGS=[
-    '/etc/candlepin',
-    '/etc/foreman',
-    '/etc/foreman-proxy',
-    '/etc/hammer',
-    '/etc/httpd',
-    '/etc/foreman-installer',
-    '/etc/pki/katello',
-    '/etc/pki/katello-certs-tools',
-    '/etc/pki/pulp',
-    '/etc/pulp',
-    '/etc/puppet',
-    '/etc/puppetlabs',
-    '/etc/qpid',
-    '/etc/qpid-dispatch',
-    '/etc/sysconfig/tomcat*',
-    '/etc/tomcat*',
-    '/root/ssl-build',
-    '/var/lib/candlepin',
-    '/var/www/html/pub',
-    '/opt/puppetlabs/puppet/cache/foreman_cache_data',
-    '/opt/puppetlabs/puppet/ssl/',
-    '/var/lib/puppet/foreman_cache_data',
-    '/var/lib/puppet/ssl'
-  ]
-
-  puts "Generating metadata ... "
   generate_metadata
-  puts "Done."
+  FileUtils.cp Dir.glob(File.join(@options[:incremental], '.*.snar')), @dir if @options[:incremental]
+  backup_config_files
 
-  FileUtils.cp Dir.glob("#{@options[:incremental]}/.*.snar"), @dir if @options[:incremental]
-
-  puts "Backing up config files... "
-  run_cmd("tar --selinux --create --gzip --file=config_files.tar.gz --listed-incremental=.config.snar #{CONFIGS.join(' ')} 2>/dev/null", [0,2])
-  puts "Done."
-
-  if @options[:online]
-    backup_db_online
-    backup_pulp_online unless @options[:config_only]
-  else
-    if @options[:logical_backup]
-        backup_db_online
+  if @options[:logical_backup]
+    @databases.each do |database|
+      online_backup(database)
     end
+  end
+
+  if @options[:snapshot]
+    snapshot_backup
+    compress_files
+  elsif @options[:online]
+    @databases.each do |database|
+      online_backup(database)
+    end
+  else
+    FileUtils.cd("/")
     `katello-service stop #{EXCLUDED}`
-    backup_db_offline
-    backup_pulp_offline unless @options[:config_only]
+    @databases.each do |database|
+      offline_backup(database)
+    end
     `katello-service start #{EXCLUDED}`
+    FileUtils.cd @dir
     compress_files
   end
 


### PR DESCRIPTION
To test:
Set up a katello instance on a LVM filesystem (cannot use the Vagrant set up). You may create partitions separately, such as mounting /var/lib/pulp separate from root. The volume group must have enough space to hold a snapshot, which by default would be about 6G.