### PR TITLE
Fixes #19263 - dont try and rm a mounted directory

### DIFF
--- a/katello/katello-remove
+++ b/katello/katello-remove
@@ -107,7 +107,6 @@ CERT_FILES=[
 ]
 
 CONTENT=[
-  '/var/cache/pulp',
   '/usr/share/foreman-proxy',
   '/usr/share/foreman-installer-katello',
   '/var/www/html/pub/katello-server-ca.crt',
@@ -119,7 +118,7 @@ CONTENT=[
   '/var/lib/pgsql',
   '/var/lib/mongodb',
   '/var/lib/katello',
-  '/var/lib/pulp/',
+  '/var/lib/pulp',
   '/var/lib/foreman',
   '/usr/share/pulp',
   '/var/lib/tomcat',
@@ -129,12 +128,18 @@ CONTENT=[
   '/usr/share/katello-installer-base',
   '/usr/share/qpid',
   '/usr/share/qpid-tools',
-  '/var/cache/candlepin',
-  '/var/cache/foreman-proxy',
   '/var/cache/',
   '/opt/theforeman',
   '/var/www/html/pub/katello-rhsm-consumer'
 ]
+
+CONTENT.map! do |dir|
+  if File.readlines('/proc/mounts').any?{ |line| line.split(" ")[1] =~ /#{dir}$/ }
+    dir + '/*'
+  else
+    dir
+  end
+end
 
 def remove
   `katello-service stop`


### PR DESCRIPTION
We could do the same for the other arrays but I doubt anyone has them mounted separately.

I've also removed `/var/cache/foo` directories as we already remove `/var/cache/` so they are kind of pointless.