### PR TITLE
Fixes #19281 - Unable to run online backup via cron

### DIFF
--- a/katello/katello-backup
+++ b/katello/katello-backup
@@ -56,9 +56,9 @@ end
 
 def backup_db_online
   puts "Backing up postgres online schema... "
-  run_cmd("runuser - postgres -c 'pg_dumpall -g > #{@dir}/pg_globals.dump'")
-  run_cmd("runuser - postgres -c 'pg_dump -Fc foreman > #{@dir}/foreman.dump'")
-  run_cmd("runuser - postgres -c 'pg_dump -Fc candlepin > #{@dir}/candlepin.dump'")
+  run_cmd("/usr/sbin/runuser - postgres -c 'pg_dumpall -g > #{@dir}/pg_globals.dump'")
+  run_cmd("/usr/sbin/runuser - postgres -c 'pg_dump -Fc foreman > #{@dir}/foreman.dump'")
+  run_cmd("/usr/sbin/runuser - postgres -c 'pg_dump -Fc candlepin > #{@dir}/candlepin.dump'")
   puts "Done."
 
   puts "Backing up mongo online schema... "


### PR DESCRIPTION
Fix is for the error while backing up foreman and candlepin database via katello-backup script via cron:

Backing up postgres db...
sh: runuser: command not found
sh: runuser: command not found
Done.

When we execute any cron job the default PATH is /usr/bin:/bin since the runuser command is present in /usr/sbin/runuser which cron can not access and execute, so backup script fails with above error. Running katello-backup script manually as a root user work without any error, issue is only when we run it via cron.

