### PR TITLE
Fixes #17060 - Addition to katello-debug.sh

### DIFF
--- a/katello/katello-debug.sh
+++ b/katello/katello-debug.sh
@@ -62,7 +62,7 @@ add_files /var/log/rhsm/*
 # Pulp
 add_files /etc/pulp/*.conf
 add_files /etc/httpd/conf.d/pulp.conf
-add_files /etc/pulp/server/plugins.conf.d/nodes/distributor/*
+add_files /etc/pulp/server/plugins.conf.d/*
 add_files /var/log/httpd/pulp-http{s,}_access_ssl.log*
 add_files /var/log/httpd/pulp-http{s,}_error_ssl.log*
 add_files /etc/default/pulp*
@@ -139,6 +139,7 @@ echo "db.task_status.find({state:{\$ne: \"finished\"}}).pretty().shellPrint()" >
 add_cmd "mongo pulp_database $TEMP_DIR/pulp_running_tasks.js" "pulp-running_tasks"
 
 add_cmd "hammer ping" "hammer-ping"
+add_cmd "katello-service status" "katello_service_status"
 
 # Legend:
 # * - already collected by sosreport tool (skip when -g option was provided)


### PR DESCRIPTION
Added below details 

- Collect below files from /etc/pulp/server/plugins.conf.d/ which include the proxy configuration details
docker_importer.json, iso_importer.json, ostree_distributor.json,  ostree_importer.json, puppet_importer.json, yum_importer.json

- Collect katello-service status command output which is helpful while debugging issues

Removed : 
- Removed entry for /etc/pulp/server/plugins.conf.d/nodes/distributor/* since we are not using nodes feature and the directory does not exist on satellite.