### PR TITLE
python-urllib3: use https links in spec file

### DIFF
--- a/python-urllib3/python-urllib3.spec
+++ b/python-urllib3/python-urllib3.spec
@@ -12,8 +12,8 @@ Release:        2.katello%{?dist}
 Summary:        Python HTTP library with thread-safe connection pooling and file post
 
 License:        MIT
-URL:            http://urllib3.readthedocs.org/
-Source0:        http://pypi.python.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+URL:            https://urllib3.readthedocs.io/
+Source0:        https://pypi.python.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
 
 # Patch to change default behaviour to check SSL certs for validity
 # https://bugzilla.redhat.com/show_bug.cgi?id=855320


### PR DESCRIPTION
otherwise git-annex chokes on the redirect
while at it, also fix up readthedocs url