### PR TITLE
Refs #18874: jquery-ui-rails is no longer required

### DIFF
--- a/rubygem-katello/rubygem-katello.spec
+++ b/rubygem-katello/rubygem-katello.spec
@@ -45,7 +45,6 @@ Requires: %{?scl_prefix}rubygem(gettext_i18n_rails)
 Requires: %{?scl_prefix}rubygem(apipie-rails) >= 0.1.1
 Requires: %{?scl_prefix}rubygem(runcible) >= 2.0.0
 Requires: %{?scl_prefix}rubygem(anemone)
-Requires: %{?scl_prefix}rubygem(jquery-ui-rails)
 Requires: %{?scl_prefix}rubygem(deface) >= 1.0.0
 Requires: %{?scl_prefix}rubygem(deface) < 2.0.0
 Requires: %{?scl_prefix}rubygem(qpid_messaging)
@@ -65,7 +64,6 @@ BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails)
 BuildRequires: %{?scl_prefix}rubygem(apipie-rails) >= 0.1.1
 BuildRequires: %{?scl_prefix}rubygem(runcible) >= 2.0.0
 BuildRequires: %{?scl_prefix}rubygem(anemone)
-BuildRequires: %{?scl_prefix}rubygem(jquery-ui-rails)
 BuildRequires: %{?scl_prefix}rubygem(deface) >= 1.0.0
 BuildRequires: %{?scl_prefix}rubygem(deface) < 2.0.0
 BuildRequires: %{?scl_prefix}rubygem(qpid_messaging)


### PR DESCRIPTION
Based on the removal from the codebase -- http://projects.theforeman.org/issues/18874