### PR TITLE
Fixes #19941 - make katello-remove remove all RPMs in one go

### DIFF
--- a/katello/katello-remove
+++ b/katello/katello-remove
@@ -145,10 +145,12 @@ def remove
   `katello-service stop`
 
   puts "Removing RPMs"
+  packages = []
   RPMS.each do | rpm |
-    packages =  `rpm -qa | grep "#{rpm}"`
-    packages.lines.each { | package | `yum erase -y "#{ package.strip }" > /dev/null 2>&1` }
+    rpmpackages = `rpm -qa | grep "#{rpm}"`
+    packages += rpmpackages.lines.map(&:chomp)
   end
+  `yum erase -y #{packages.join(" ")} > /dev/null 2>&1`
 
   puts "Cleaning up configuration files"
   FileUtils.rm_rf CONFIG_FILES


### PR DESCRIPTION
A small benchmark on CentOS7 with 272 packages to be removed:

without the patch:

    real    9m0.638s
    user    4m8.864s
    sys     0m31.247s

with the patch:

    real    4m32.901s
    user    1m14.804s
    sys     0m15.476s