### PR TITLE
Fixes #20702 - require python-argparse on EL5 and EL6

### DIFF
--- a/katello-host-tools/katello-host-tools.spec
+++ b/katello-host-tools/katello-host-tools.spec
@@ -23,6 +23,10 @@ Requires: crontabs
 Requires: python-simplejson
 %endif
 
+%if 0%{?rhel} == 5 || 0%{?rhel} == 6
+Requires: python-argparse
+%endif
+
 %if 0%{?sles_version}
 BuildRequires: python-devel >= 2.6
 %else


### PR DESCRIPTION
python-argparse is available in EPEL5 for EL5 and in EL6 proper