### PR TITLE
Added nicely formatted list of services

### DIFF
--- a/katello/katello-service
+++ b/katello/katello-service
@@ -86,6 +86,10 @@ def manage_services(action)
     end
   end
 
+  SERVICES.keys.each do |se|
+    status = failures.include?(se) ? "FAIL" : " OK "
+    printf "Service %-40s [ %s ]\n", se, status
+  end
   if failures.empty?
     puts "Success!"
     `logger -t #{$0} -p daemon.info '*** #{action} finished successfuly ***'`

--- a/katello/katello-service
+++ b/katello/katello-service
@@ -91,10 +91,8 @@ def manage_services(action)
     printf "Service %-40s [ %s ]\n", se, status
   end
   if failures.empty?
-    puts "Success!"
     `logger -t #{$0} -p daemon.info '*** #{action} finished successfuly ***'`
   else
-    puts "Some services failed to #{action}: #{failures.join(',')}"
     `logger -t #{$0} -p daemon.warning '*** #{action} failed: #{failures.join(',')} ***'`
     exit 1
   end


### PR DESCRIPTION
We do print "Done!" string when all operations (start|stop|status) were successful and "Some services failed" in other case, but particularly the successful operation is not easily visible and I tend to scroll up through unreadable output from systemd statuses.

This patch adds nicely formatted output which is clear and improves UX with this script:

```
...
Redirecting to /bin/systemctl status goferd.service
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; disabled; vendor preset: disabled)
   Active: active (running) since Wed 2017-09-06 12:47:54 CEST; 14min ago
 Main PID: 16168 (python)
   CGroup: /system.slice/goferd.service
           └─16168 python /usr/bin/goferd --foreground

Sep 06 12:47:56 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][worker-0] gofer.messaging.adapter.connect:30 - connected: proton+amqps://sat-r220-02.lab.eng.rdu2.redhat.com:5647
Sep 06 12:47:56 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][worker-0] root:512 - connected to sat-r220-02.lab.eng.rdu2.redhat.com:5647
Sep 06 12:47:57 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][worker-0] gofer.messaging.adapter.proton.connection:131 - closed: proton+amqps://sat-r220-02.lab.eng.rdu2.redhat.com:5647
Sep 06 12:47:57 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][pulp.agent.0d8f6f56-dfd4-4ea7-af6a-99a7248c1be5] gofer.messaging.adapter.connect:28 - connecting: proton+amqps://sat-r220-02.lab.eng.rdu2.redhat.com:5647
Sep 06 12:47:57 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][pulp.agent.0d8f6f56-dfd4-4ea7-af6a-99a7248c1be5] gofer.messaging.adapter.proton.connection:87 - open: URL: amqps://sat-r220-02.lab.eng.rdu2.redhat.com:5647|SSL: ca: /etc/rhsm/ca/katello-default-ca.pem|key: None|certificate: /etc/pki/consumer/bundle.pem|host-validation: None
Sep 06 12:47:57 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][pulp.agent.0d8f6f56-dfd4-4ea7-af6a-99a7248c1be5] root:490 - connecting to sat-r220-02.lab.eng.rdu2.redhat.com:5647...
Sep 06 12:47:57 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][worker-0] gofer.agent.plugin:368 - plugin:katelloplugin, attached => pulp.agent.0d8f6f56-dfd4-4ea7-af6a-99a7248c1be5
Sep 06 12:47:58 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][pulp.agent.0d8f6f56-dfd4-4ea7-af6a-99a7248c1be5] gofer.messaging.adapter.proton.connection:92 - opened: proton+amqps://sat-r220-02.lab.eng.rdu2.redhat.com:5647
Sep 06 12:47:58 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][pulp.agent.0d8f6f56-dfd4-4ea7-af6a-99a7248c1be5] gofer.messaging.adapter.connect:30 - connected: proton+amqps://sat-r220-02.lab.eng.rdu2.redhat.com:5647
Sep 06 12:47:58 zzzap.lab.eng.brq.redhat.com goferd[16168]: [INFO][pulp.agent.0d8f6f56-dfd4-4ea7-af6a-99a7248c1be5] root:512 - connected to sat-r220-02.lab.eng.rdu2.redhat.com:5647
Service mongod                                   [  OK  ]
Service postgresql                               [  OK  ]
Service qpidd                                    [ FAIL ]
Service qdrouterd                                [  OK  ]
Service squid                                    [  OK  ]
Service tomcat                                   [  OK  ]
Service tomcat6                                  [  OK  ]
Service pulp_workers                             [  OK  ]
Service pulp_celerybeat                          [  OK  ]
Service pulp_resource_manager                    [  OK  ]
Service pulp_streamer                            [  OK  ]
Service foreman-proxy                            [  OK  ]
Service smart_proxy_dynflow_core                 [  OK  ]
Service httpd                                    [  OK  ]
Service puppetserver                             [  OK  ]
Service foreman-tasks                            [  OK  ]
Service goferd                                   [  OK  ]
Some services failed to status: qpidd


```