### PR TITLE
Fixes #21028 - make k-c-h --help work even without an installed system

### DIFF
--- a/katello/helper.rb
+++ b/katello/helper.rb
@@ -1,7 +1,12 @@
 module KatelloUtilities
   module Helper
     def last_scenario
-      File.basename(File.readlink("/etc/foreman-installer/scenarios.d/last_scenario.yaml")).split(".")[0]
+      last_scenario_yaml = '/etc/foreman-installer/scenarios.d/last_scenario.yaml'
+      if File.exists?(last_scenario_yaml)
+        File.basename(File.readlink(last_scenario_yaml)).split(".")[0]
+      else
+        'katello'
+      end
     end
 
     def accepted_scenarios


### PR DESCRIPTION
/etc/foreman-installer/scenarios.d/last_scenario.yaml might or might not
be there, so let's fall back to `katello` scenario if the file cannot be
found.