### PR TITLE
Refs #20821 - add utility helper files to fpc installs

### DIFF
--- a/katello/katello.spec
+++ b/katello/katello.spec
@@ -183,6 +183,10 @@ Provides a federation of katello services
 %{_sbindir}/katello-restore
 %{_sbindir}/katello-change-hostname
 %{_sbindir}/katello-remove
+%{_datarootdir}/katello/restore.rb
+%{_datarootdir}/katello/backup.rb
+%{_datarootdir}/katello/hostname-change.rb
+%{_datarootdir}/katello/helper.rb
 
 # ------ Service ----------------
 %package service


### PR DESCRIPTION
The ruby helper files for katello-* utilities are to be installed
in /usr/share/katello on both the server and fpc. They need to
be included in the foreman-proxy-content package