### PR TITLE
Fixes #21220 - make k-c-h command name easily changed

### DIFF
--- a/katello/hostname-change.rb
+++ b/katello/hostname-change.rb
@@ -11,17 +11,18 @@ module KatelloUtilities
   class HostnameChange
     include ::KatelloUtilities::Helper
 
-    def initialize(proxy, plural_proxy, proxy_hyphenated, program=nil, scenario=nil, accepted_scenarios=nil)
+    def initialize(init_options)
       @default_program = self.get_default_program
-      @proxy = proxy
-      @plural_proxy = plural_proxy
-      @proxy_hyphenated = proxy_hyphenated
-      @accepted_scenarios = accepted_scenarios
-
+      @proxy = init_options.fetch(:proxy)
+      @plural_proxy = init_options.fetch(:plural_proxy)
+      @proxy_hyphenated = init_options.fetch(:proxy_hyphenated)
+      @command_prefix = init_options.fetch(:command_prefix)
+      @accepted_scenarios = init_options.fetch(:accepted_scenarios, nil)
       @last_scenario = self.last_scenario
+
       @options = {}
-      @options[:program] = program || @default_program
-      @options[:scenario] = scenario || @last_scenario
+      @options[:program] = init_options.fetch(:program, @default_program)
+      @options[:scenario] = init_options.fetch(:scenario, @last_scenario)
       @foreman_proxy_content = @options[:scenario] == @proxy_hyphenated
 
       setup_opt_parser
@@ -77,7 +78,7 @@ module KatelloUtilities
     def get_fpc_answers
       register_in_foreman = false
       certs_tar = @options[:certs_tar]
-      " --foreman-proxy-register-in-foreman #{register_in_foreman} --#{@proxy_hyphenated}-certs-tar #{certs_tar}"
+      " --foreman-proxy-register-in-foreman #{register_in_foreman} --foreman-proxy-content-certs-tar #{certs_tar}"
     end
 
     def precheck
@@ -179,10 +180,10 @@ module KatelloUtilities
 
     def setup_opt_parser
       @opt_parser = OptionParser.new do |opt|
-        opt.banner = "usage: katello-change-hostname hostname [options]"
+        opt.banner = "usage: #{@command_prefix}-change-hostname hostname [options]"
         opt.separator  ""
         opt.separator  "example:"
-        opt.separator  " katello-change-hostname foo.example.com -u admin -p changeme"
+        opt.separator  "#{@command_prefix}-change-hostname foo.example.com -u admin -p changeme"
         opt.separator  ""
         opt.separator  "options"
 

--- a/katello/katello-change-hostname
+++ b/katello/katello-change-hostname
@@ -9,7 +9,14 @@ end
 
 require File.join(UTILS_PATH, 'hostname-change.rb')
 
-hostname_change = KatelloUtilities::HostnameChange.new("Foreman Proxy", "Foreman Proxies", "foreman-proxy-content")
+options = {
+ proxy: "Foreman Proxy",
+ plural_proxy: "Foreman Proxies",
+ proxy_hyphenated: "foreman-proxy-content",
+ command_prefix: "katello"
+}
+
+hostname_change = KatelloUtilities::HostnameChange.new(options)
 
 if hostname_change.accepted_scenarios.include? hostname_change.last_scenario
   hostname_change.run


### PR DESCRIPTION
We need this to backport these changes.